### PR TITLE
build onedir binarys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,15 +34,19 @@ jobs:
           esp_flasher -h
       - name: Run PyInstaller
         run: |
-          python -m PyInstaller.__main__ -F -w -n ESP-Flasher -i icon.ico --add-data "esp_flasher/stubs/*.json;esp_flasher/stubs" esp_flasher\__main__.py
+          python -m PyInstaller.__main__ -w -n ESP-Flasher -i icon.ico --add-data "esp_flasher/stubs/*.json;esp_flasher/stubs" esp_flasher\__main__.py
       - name: Test binary
         shell: bash
         run: |
-          dist/ESP-Flasher.exe -h
+          dist/ESP-Flasher/ESP-Flasher.exe -h
+      - name: Create archive
+        shell: bash
+        run: |
+          cd dist && 7z a -tzip ../ESP-Flasher-Windows.zip ESP-Flasher/
       - uses: actions/upload-artifact@v7
         with:
           name: Windows
-          path: dist/ESP-Flasher.exe
+          path: ESP-Flasher-Windows.zip
 
   build-ubuntu:
     runs-on: ubuntu-latest
@@ -66,16 +70,13 @@ jobs:
          esp_flasher -h
      - name: Run PyInstaller
        run: |
-         python -m PyInstaller.__main__ -F -w -n ESP-Flasher -i icon.ico --add-data "esp_flasher/stubs/*.json:esp_flasher/stubs" esp_flasher/__main__.py
+         python -m PyInstaller.__main__ -w -n ESP-Flasher -i icon.ico --add-data "esp_flasher/stubs/*.json:esp_flasher/stubs" esp_flasher/__main__.py
      - name: Test binary
        shell: bash
        run: |
-         dist/ESP-Flasher -h 
-     - name: Move app
-       run: |
-         mv dist/ESP-Flasher ESP-Flasher
+         dist/ESP-Flasher/ESP-Flasher -h
      - name: 'Tar files'
-       run: tar -cvf Ubuntu.tar ESP-Flasher
+       run: tar -cvf Ubuntu.tar -C dist ESP-Flasher/
      - uses: actions/upload-artifact@v7
        with:
          name: Ubuntu
@@ -99,11 +100,11 @@ jobs:
           esp_flasher -h
       - name: Run PyInstaller
         run: |
-          python -m PyInstaller.__main__ -F -w -n ESP-Flasher -i icon.icns --add-data "esp_flasher/stubs/*.json:esp_flasher/stubs" esp_flasher/__main__.py
+          python -m PyInstaller.__main__ -w -n ESP-Flasher -i icon.icns --add-data "esp_flasher/stubs/*.json:esp_flasher/stubs" esp_flasher/__main__.py
       - name: Test binary
         shell: bash
         run: |
-          dist/ESP-Flasher -h
+          dist/ESP-Flasher/ESP-Flasher -h
       - name: Move app
         run: |
           mv dist/ESP-Flasher.app ESP-Flasher-macOS.app
@@ -133,11 +134,11 @@ jobs:
           esp_flasher -h
       - name: Run PyInstaller
         run: |
-          python -m PyInstaller.__main__ -F -w -n ESP-Flasher -i icon.icns --add-data "esp_flasher/stubs/*.json:esp_flasher/stubs" esp_flasher/__main__.py
+          python -m PyInstaller.__main__ -w -n ESP-Flasher -i icon.icns --add-data "esp_flasher/stubs/*.json:esp_flasher/stubs" esp_flasher/__main__.py
       - name: Test binary
         shell: bash
         run: |
-          dist/ESP-Flasher -h 
+          dist/ESP-Flasher/ESP-Flasher -h
       - name: Move app
         run: |
           mv dist/ESP-Flasher.app ESP-Flasher-macOSarm.app

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@ MANIFEST
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
-*.spec
 
 # Installer logs
 pip-log.txt

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -98,10 +98,10 @@ Download the latest release for your operating system from the [Releases page](h
 
 | Platform | Binary |
 |----------|--------|
-| Windows | `ESP-Flasher.exe` |
+| Windows | `ESP-Flasher-Windows.zip` (extract and run `ESP-Flasher.exe`) |
 | macOS (Intel) | `ESP-Flasher-macOS.app` (tar archive) |
 | macOS (ARM/Apple Silicon) | `ESP-Flasher-macOSarm.app` (tar archive) |
-| Linux (Ubuntu) | `ESP-Flasher` (tar archive) |
+| Linux (Ubuntu) | `Ubuntu.tar` (extract and run `ESP-Flasher/ESP-Flasher`) |
 
 ### From PyPI
 
@@ -484,15 +484,15 @@ pip install -e .
 ### macOS
 
 ```bash
-python -m PyInstaller.__main__ -F -w -n ESP-Flasher -i icon.icns --add-data "esp_flasher/stubs/*.json:esp_flasher/stubs" esp_flasher/__main__.py
+python -m PyInstaller.__main__ -w -n ESP-Flasher -i icon.icns --add-data "esp_flasher/stubs/*.json:esp_flasher/stubs" esp_flasher/__main__.py
 ```
 
 Or using a virtual environment:
 ```bash
-/<path>/ESP_Flasher/.venv/bin/pyinstaller -F -w -n ESP-Flasher -i icon.icns --add-data "esp_flasher/stubs/*.json:esp_flasher/stubs" esp_flasher/__main__.py
+/<path>/ESP_Flasher/.venv/bin/pyinstaller -w -n ESP-Flasher -i icon.icns --add-data "esp_flasher/stubs/*.json:esp_flasher/stubs" esp_flasher/__main__.py
 ```
 
-The output is located at `dist/ESP-Flasher.app`.
+The output is located at `dist/ESP-Flasher.app` (onedir bundle for fast startup).
 
 ### macOS (ARM)
 
@@ -501,19 +501,19 @@ Same command as macOS Intel — PyInstaller builds for the native architecture.
 ### Windows
 
 ```bash
-python -m PyInstaller.__main__ -F -w -n ESP-Flasher -i icon.ico --add-data "esp_flasher/stubs/*.json;esp_flasher/stubs" esp_flasher\__main__.py
+python -m PyInstaller.__main__ -w -n ESP-Flasher -i icon.ico --add-data "esp_flasher/stubs/*.json;esp_flasher/stubs" esp_flasher\__main__.py
 ```
 
-The output is located at `dist\ESP-Flasher.exe`.
+The output is located at `dist\ESP-Flasher\` (directory containing `ESP-Flasher.exe` and dependencies).
 
 ### Linux (Ubuntu)
 
 ```bash
 sudo apt install libnotify-dev libsdl2-dev
-python -m PyInstaller.__main__ -F -w -n ESP-Flasher -i icon.ico --add-data "esp_flasher/stubs/*.json:esp_flasher/stubs" esp_flasher/__main__.py
+python -m PyInstaller.__main__ -w -n ESP-Flasher -i icon.ico --add-data "esp_flasher/stubs/*.json:esp_flasher/stubs" esp_flasher/__main__.py
 ```
 
-The output is located at `dist/ESP-Flasher`.
+The output is located at `dist/ESP-Flasher/` (directory containing the executable and dependencies).
 
 ---
 
@@ -531,10 +531,10 @@ It builds binaries for four platforms in parallel:
 
 | Job | Runner | Python | Output |
 |-----|--------|--------|--------|
-| `build-windows` | `windows-latest` | 3.13 | `ESP-Flasher.exe` |
-| `build-ubuntu` | `ubuntu-latest` | 3.13 | `ESP-Flasher` (tar) |
-| `build-macos` | `macos-15-intel` | 3.13 | `ESP-Flasher-macOS.app` (tar) |
-| `build-macos-arm` | `macos-15` | 3.13 | `ESP-Flasher-macOSarm.app` (tar) |
+| `build-windows` | `windows-latest` | 3.13 | `ESP-Flasher-Windows.zip` (onedir) |
+| `build-ubuntu` | `ubuntu-latest` | 3.13 | `Ubuntu.tar` (onedir) |
+| `build-macos` | `macos-15-intel` | 3.13 | `ESP-Flasher-macOS.app` (onedir, tar) |
+| `build-macos-arm` | `macos-15` | 3.13 | `ESP-Flasher-macOSarm.app` (onedir, tar) |
 
 On tagged releases, a `release` job uploads all artifacts to the GitHub Release.
 

--- a/ESP-Flasher.spec
+++ b/ESP-Flasher.spec
@@ -1,0 +1,66 @@
+# -*- mode: python ; coding: utf-8 -*-
+import sys
+
+# Determine the correct icon and executable name based on platform
+if sys.platform == 'darwin':
+    icon_file = 'icon.icns'
+    exe_name = 'ESP-Flasher'
+elif sys.platform == 'win32':
+    icon_file = 'icon.ico'
+    exe_name = 'ESP-Flasher.exe'
+else:
+    icon_file = None
+    exe_name = 'ESP-Flasher'
+
+
+a = Analysis(
+    ['esp_flasher/__main__.py'],
+    pathex=[],
+    binaries=[],
+    datas=[('esp_flasher/stubs/*.json', 'esp_flasher/stubs')],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name=exe_name,
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=icon_file,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='ESP-Flasher',
+)
+
+# Only create macOS app bundle on macOS
+if sys.platform == 'darwin':
+    app = BUNDLE(
+        coll,
+        name='ESP-Flasher.app',
+        icon='icon.icns',
+        bundle_identifier=None,
+    )

--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ If you want to build this application yourself you need to:
 - Start the GUI using `esp_flasher`. Alternatively, you can use the command line interface (
   type `esp_flasher -h` for info)
 
+To create a standalone binary, use PyInstaller with the provided spec file:
+
+```bash
+pip install -r requirements.txt -r requirements_build.txt
+pyinstaller ESP-Flasher.spec
+```
+
+For detailed build instructions, see [build-instructions.md](build-instructions.md).
+
 ### Mac OSX (compiled binary only for 11 and newer)
 
 Driver maybe needed for Mac OSx.

--- a/build-instructions.md
+++ b/build-instructions.md
@@ -29,14 +29,14 @@ Instructions for building standalone ESP-Flasher binaries using [PyInstaller](ht
 3. Install dependencies (see [Prerequisites](#prerequisites-all-platforms))
 4. Build the binary:
    ```bash
-   python -m PyInstaller.__main__ -F -w -n ESP-Flasher -i icon.ico --add-data "esp_flasher/stubs/*.json;esp_flasher/stubs" esp_flasher\__main__.py
+   python -m PyInstaller.__main__ -w -n ESP-Flasher -i icon.ico --add-data "esp_flasher/stubs/*.json;esp_flasher/stubs" esp_flasher\__main__.py
    ```
 5. Verify the binary:
    ```bash
-   dist\ESP-Flasher.exe -h
+   dist\ESP-Flasher\ESP-Flasher.exe -h
    ```
 
-The output is `dist\ESP-Flasher.exe`.
+The output is `dist\ESP-Flasher\` (a directory containing the executable and all dependencies).
 
 ---
 
@@ -46,14 +46,14 @@ The output is `dist\ESP-Flasher.exe`.
 2. Install dependencies (see [Prerequisites](#prerequisites-all-platforms))
 3. Build the binary:
    ```bash
-   .venv/bin/pyinstaller -F -w -n ESP-Flasher -i icon.icns --add-data "esp_flasher/stubs/*.json:esp_flasher/stubs" esp_flasher/__main__.py
+   .venv/bin/pyinstaller -w -n ESP-Flasher -i icon.icns --add-data "esp_flasher/stubs/*.json:esp_flasher/stubs" esp_flasher/__main__.py
    ```
 4. Verify the binary:
    ```bash
-   dist/ESP-Flasher -h
+   dist/ESP-Flasher/ESP-Flasher -h
    ```
 
-The output is `dist/ESP-Flasher.app`.
+The output is `dist/ESP-Flasher.app` (an app bundle using the onedir layout for fast startup).
 
 ---
 
@@ -67,7 +67,7 @@ Same steps as macOS Intel — PyInstaller builds for the native architecture aut
 2. Activate it and install all dependencies (see [Prerequisites](#prerequisites-all-platforms))
 3. Build the binary using the venv's PyInstaller:
    ```bash
-   .venv/bin/pyinstaller -F -w -n ESP-Flasher -i icon.icns --add-data "esp_flasher/stubs/*.json:esp_flasher/stubs" esp_flasher/__main__.py
+   .venv/bin/pyinstaller -w -n ESP-Flasher -i icon.icns --add-data "esp_flasher/stubs/*.json:esp_flasher/stubs" esp_flasher/__main__.py
    ```
 
 The output is `dist/ESP-Flasher.app`.
@@ -84,14 +84,14 @@ The output is `dist/ESP-Flasher.app`.
 2. Install dependencies (see [Prerequisites](#prerequisites-all-platforms))
 3. Build the binary:
    ```bash
-   python -m PyInstaller.__main__ -F -w -n ESP-Flasher -i icon.ico --add-data "esp_flasher/stubs/*.json:esp_flasher/stubs" esp_flasher/__main__.py
+   python -m PyInstaller.__main__ -w -n ESP-Flasher -i icon.ico --add-data "esp_flasher/stubs/*.json:esp_flasher/stubs" esp_flasher/__main__.py
    ```
 4. Verify the binary:
    ```bash
-   dist/ESP-Flasher -h
+   dist/ESP-Flasher/ESP-Flasher -h
    ```
 
-The output is `dist/ESP-Flasher`.
+The output is `dist/ESP-Flasher/` (a directory containing the executable and all dependencies).
 
 > **Note:** On Linux, your user needs serial port access. Run once:
 > ```bash
@@ -99,16 +99,13 @@ The output is `dist/ESP-Flasher`.
 > ```
 > Then log out and back in.
 
-
-This produces `dist/ESP-Flasher.app` with the bundled icon and settings.
-
 ---
 
 ## Output summary
 
 | Platform | Output |
 |----------|--------|
-| Windows | `dist\ESP-Flasher.exe` |
-| macOS (Intel) | `dist/ESP-Flasher.app` |
-| macOS (ARM) | `dist/ESP-Flasher.app` |
-| Linux | `dist/ESP-Flasher` |
+| Windows | `dist\ESP-Flasher\` (directory with `ESP-Flasher.exe`) |
+| macOS (Intel) | `dist/ESP-Flasher.app` (onedir bundle) |
+| macOS (ARM) | `dist/ESP-Flasher.app` (onedir bundle) |
+| Linux | `dist/ESP-Flasher/` (directory with `ESP-Flasher`) |

--- a/build-instructions.md
+++ b/build-instructions.md
@@ -22,60 +22,84 @@ Instructions for building standalone ESP-Flasher binaries using [PyInstaller](ht
 
 ---
 
-## Windows
+## Quick Build (Recommended)
 
+The easiest way to build the application is using the provided spec file, which automatically handles platform-specific settings (icons, file extensions, etc.):
+
+```bash
+pyinstaller ESP-Flasher.spec
+```
+
+This works on all platforms (Windows, macOS, Linux) and produces the appropriate output:
+- **Windows**: `dist\ESP-Flasher\ESP-Flasher.exe`
+- **macOS**: `dist/ESP-Flasher.app`
+- **Linux**: `dist/ESP-Flasher/ESP-Flasher`
+
+---
+
+## Platform-Specific Instructions
+
+### Windows
+
+**Option 1: Using the spec file (recommended)**
 1. Install Python >= 3.9 from [python.org](https://www.python.org/downloads/) (make sure to check "Add to PATH")
 2. Open a terminal in the project directory
 3. Install dependencies (see [Prerequisites](#prerequisites-all-platforms))
 4. Build the binary:
    ```bash
-   python -m PyInstaller.__main__ -w -n ESP-Flasher -i icon.ico --add-data "esp_flasher/stubs/*.json;esp_flasher/stubs" esp_flasher\__main__.py
+   pyinstaller ESP-Flasher.spec
    ```
 5. Verify the binary:
    ```bash
    dist\ESP-Flasher\ESP-Flasher.exe -h
    ```
 
+**Option 2: Manual PyInstaller command**
+```bash
+python -m PyInstaller.__main__ -w -n ESP-Flasher.exe -i icon.ico --add-data "esp_flasher/stubs/*.json;esp_flasher/stubs" esp_flasher\__main__.py
+```
+
 The output is `dist\ESP-Flasher\` (a directory containing the executable and all dependencies).
 
 ---
 
-## macOS (Intel)
+### macOS (Intel & Apple Silicon)
 
+**Option 1: Using the spec file (recommended)**
 1. Install Python >= 3.9
 2. Install dependencies (see [Prerequisites](#prerequisites-all-platforms))
 3. Build the binary:
    ```bash
-   .venv/bin/pyinstaller -w -n ESP-Flasher -i icon.icns --add-data "esp_flasher/stubs/*.json:esp_flasher/stubs" esp_flasher/__main__.py
+   pyinstaller ESP-Flasher.spec
    ```
 4. Verify the binary:
    ```bash
-   dist/ESP-Flasher/ESP-Flasher -h
+   dist/ESP-Flasher.app/Contents/MacOS/ESP-Flasher -h
    ```
+
+**Option 2: Manual PyInstaller command**
+```bash
+pyinstaller -w -n ESP-Flasher -i icon.icns --add-data "esp_flasher/stubs/*.json:esp_flasher/stubs" esp_flasher/__main__.py
+```
 
 The output is `dist/ESP-Flasher.app` (an app bundle using the onedir layout for fast startup).
 
----
+PyInstaller builds for the native architecture automatically (Intel or ARM).
 
-## macOS (ARM / Apple Silicon)
-
-Same steps as macOS Intel — PyInstaller builds for the native architecture automatically.
-
-### Using a virtual environment (recommended)
+#### Using a virtual environment (recommended)
 
 1. Open your IDE (e.g. VS Code) and create a virtual environment
 2. Activate it and install all dependencies (see [Prerequisites](#prerequisites-all-platforms))
 3. Build the binary using the venv's PyInstaller:
    ```bash
-   .venv/bin/pyinstaller -w -n ESP-Flasher -i icon.icns --add-data "esp_flasher/stubs/*.json:esp_flasher/stubs" esp_flasher/__main__.py
+   .venv/bin/pyinstaller ESP-Flasher.spec
    ```
-
-The output is `dist/ESP-Flasher.app`.
 
 ---
 
-## Linux (Ubuntu / Debian)
+### Linux (Ubuntu / Debian)
 
+**Option 1: Using the spec file (recommended)**
 1. Install Python >= 3.9 and required system libraries:
    ```bash
    sudo apt update
@@ -84,12 +108,17 @@ The output is `dist/ESP-Flasher.app`.
 2. Install dependencies (see [Prerequisites](#prerequisites-all-platforms))
 3. Build the binary:
    ```bash
-   python -m PyInstaller.__main__ -w -n ESP-Flasher -i icon.ico --add-data "esp_flasher/stubs/*.json:esp_flasher/stubs" esp_flasher/__main__.py
+   pyinstaller ESP-Flasher.spec
    ```
 4. Verify the binary:
    ```bash
    dist/ESP-Flasher/ESP-Flasher -h
    ```
+
+**Option 2: Manual PyInstaller command**
+```bash
+python -m PyInstaller.__main__ -w -n ESP-Flasher -i icon.ico --add-data "esp_flasher/stubs/*.json:esp_flasher/stubs" esp_flasher/__main__.py
+```
 
 The output is `dist/ESP-Flasher/` (a directory containing the executable and all dependencies).
 
@@ -105,7 +134,17 @@ The output is `dist/ESP-Flasher/` (a directory containing the executable and all
 
 | Platform | Output |
 |----------|--------|
-| Windows | `dist\ESP-Flasher\` (directory with `ESP-Flasher.exe`) |
+| Windows | `dist\ESP-Flasher\ESP-Flasher.exe` |
 | macOS (Intel) | `dist/ESP-Flasher.app` (onedir bundle) |
 | macOS (ARM) | `dist/ESP-Flasher.app` (onedir bundle) |
-| Linux | `dist/ESP-Flasher/` (directory with `ESP-Flasher`) |
+| Linux | `dist/ESP-Flasher/ESP-Flasher` |
+
+---
+
+## Spec File Benefits
+
+Using `ESP-Flasher.spec` provides several advantages:
+- **Automatic platform detection**: Correct icon format and file extension for each OS
+- **Consistent builds**: Same command works on all platforms
+- **Maintainability**: Single source of truth for build configuration
+- **macOS app bundle**: Only created on macOS (not on Windows/Linux)

--- a/esp_flasher/const.py
+++ b/esp_flasher/const.py
@@ -2,6 +2,12 @@ import re
 
 __version__ = "4.1.0"
 
+# Default window geometry
+DEFAULT_WINDOW_WIDTH = 800
+DEFAULT_WINDOW_HEIGHT = 600
+DEFAULT_WINDOW_X = 100
+DEFAULT_WINDOW_Y = 100
+
 ESP32_DEFAULT_OTA_DATA = (
     "https://raw.githubusercontent.com/Jason2866/ESP_Flasher/factory/"
     "partitions/boot_app0.bin"

--- a/esp_flasher/gui.py
+++ b/esp_flasher/gui.py
@@ -9,10 +9,12 @@ from PyQt5.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout,
                              QFileDialog, QTextEdit, QGroupBox, QGridLayout,
                              QLineEdit)
 from PyQt5.QtGui import QColor, QPalette
-from PyQt5.QtCore import pyqtSignal, QObject, Qt
+from PyQt5.QtCore import pyqtSignal, QObject, Qt, QSettings
 
 from esp_flasher.own_esptool import get_port_list
-from esp_flasher.const import __version__
+from esp_flasher.const import (__version__, DEFAULT_WINDOW_WIDTH, 
+                               DEFAULT_WINDOW_HEIGHT, DEFAULT_WINDOW_X, 
+                               DEFAULT_WINDOW_Y)
 from esp_flasher.console_color import ColoredConsole
 
 class FlashingThread(threading.Thread):
@@ -60,6 +62,9 @@ class MainWindow(QMainWindow):
         self.command_history = []  # Store command history
         self.history_index = -1  # Current position in history (-1 = not browsing)
         self.current_input = ""  # Store current input when browsing history
+        
+        # Initialize settings
+        self.settings = QSettings('Tasmota', 'ESP-Flasher')
 
         self.init_ui()
         # Redirect stdout to colored console
@@ -69,10 +74,15 @@ class MainWindow(QMainWindow):
         # Connect flash signals
         self.flash_finished.connect(self.on_flash_finished)
         self.flash_failed.connect(self.on_flash_failed)
+        
+        # Restore window geometry
+        self.restore_window_geometry()
 
     def init_ui(self):
         self.setWindowTitle(f"Tasmota-Esp-Flasher {__version__}")
-        self.setGeometry(100, 100, 800, 600)
+        # Set default size (will be overridden by saved settings if available)
+        self.setGeometry(DEFAULT_WINDOW_X, DEFAULT_WINDOW_Y, 
+                        DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT)
 
         central_widget = QWidget()
         self.setCentralWidget(central_widget)
@@ -480,12 +490,25 @@ class MainWindow(QMainWindow):
         """Clear the console"""
         self._colored_console.clear()
     
+    def restore_window_geometry(self):
+        """Restore window size and position from settings"""
+        geometry = self.settings.value('window/geometry')
+        if geometry:
+            self.restoreGeometry(geometry)
+    
+    def save_window_geometry(self):
+        """Save window size and position to settings"""
+        self.settings.setValue('window/geometry', self.saveGeometry())
+    
     def closeEvent(self, event):
         """Handle window close event"""
         if self._is_flashing:
             self.show_log_error("Cannot close window while flashing is in progress")
             event.ignore()
             return
+        
+        # Save window geometry before closing
+        self.save_window_geometry()
             
         if self._serial_port and self._serial_port.is_open:
             self.disconnect_from_port()

--- a/requirements_build.txt
+++ b/requirements_build.txt
@@ -1,2 +1,2 @@
-pyinstaller>=4.8,<7
+pyinstaller>=6.13,<7
 wheel


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build and packaging process across Windows, macOS, and Ubuntu, switching to directory-based application bundles.
  * Changed distribution artifacts and uploadable archives (Windows now provides a ZIP; Ubuntu provides a TAR containing the app directory).
  * Bumped PyInstaller minimum build dependency.

* **Documentation**
  * Revised install/build instructions and download guidance to reflect new archive formats and output locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->